### PR TITLE
Support notional-based quantity conversion

### DIFF
--- a/aster_volume_bot/api.py
+++ b/aster_volume_bot/api.py
@@ -165,6 +165,21 @@ class ApiClient:
         params = {"symbol": symbol, "leverage": leverage}
         return self._request("POST", "/fapi/v1/leverage", params=params, signed=True)
 
+    def get_symbol_price(self, symbol: str) -> Decimal:
+        """Fetches the latest ticker price for *symbol*."""
+
+        response = self._request("GET", "/fapi/v1/ticker/price", params={"symbol": symbol})
+        try:
+            return Decimal(str(response["price"]))
+        except (KeyError, ValueError, TypeError) as exc:  # pragma: no cover - protective guard
+            raise ApiError(500, None, "Malformed price payload returned by ticker endpoint") from exc
+
+    def get_exchange_info(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        """Returns exchange metadata, optionally scoped to *symbol*."""
+
+        params = {"symbol": symbol} if symbol is not None else None
+        return self._request("GET", "/fapi/v1/exchangeInfo", params=params)
+
     def place_order(
         self,
         symbol: str,

--- a/aster_volume_bot/bot.py
+++ b/aster_volume_bot/bot.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from decimal import Decimal
+from decimal import Decimal, ROUND_DOWN
 import json
 import logging
 import time
@@ -107,6 +107,9 @@ class DeltaNeutralVolumeBot:
             Path(self.status_file).parent.mkdir(parents=True, exist_ok=True)
         self._stop = False
         self._last_status_write = 0.0
+        self._step_size_cache: Dict[str, Decimal] = {}
+        self._last_quantity: Optional[Decimal] = None
+        self._last_price: Optional[Decimal] = None
 
     # ------------------------------------------------------------------
     # Formatting helpers
@@ -134,9 +137,12 @@ class DeltaNeutralVolumeBot:
     def _format_metric(self, label: str, value: Decimal, color: str) -> str:
         return f"{_paint(label, DIM)} {_paint(self._format_decimal(value), color, BOLD)}"
 
-    def _order_description(self) -> str:
+    def _order_description(self, quantity: Optional[Decimal] = None) -> str:
         if self.config.order_notional is not None:
-            return self._format_metric("Notional (USDT)", self.config.order_notional, FG_CYAN)
+            metrics = [self._format_metric("Notional (USDT)", self.config.order_notional, FG_CYAN)]
+            if quantity is not None:
+                metrics.append(self._format_metric("Quantity", quantity, FG_CYAN))
+            return "  ".join(metrics)
         if self.config.order_quantity is None:  # pragma: no cover - guarded by config validation
             raise ValueError("Bot configuration missing order size definition")
         return self._format_metric("Quantity", self.config.order_quantity, FG_CYAN)
@@ -151,12 +157,46 @@ class DeltaNeutralVolumeBot:
         ]
         return f"{_paint('│', DIM)} " + "  ".join(parts)
 
-    def _order_parameters(self) -> Dict[str, Decimal]:
-        if self.config.order_notional is not None:
-            return {"quote_order_qty": self.config.order_notional}
-        if self.config.order_quantity is None:  # pragma: no cover - guarded by config validation
-            raise ValueError("Bot configuration missing order quantity and order value")
-        return {"quantity": self.config.order_quantity}
+    def _get_symbol_step_size(self, client: ApiClient, symbol: str) -> Decimal:
+        if symbol in self._step_size_cache:
+            return self._step_size_cache[symbol]
+        exchange_info = client.get_exchange_info(symbol)
+        symbols = exchange_info.get("symbols", [])
+        for symbol_info in symbols:
+            if symbol_info.get("symbol") != symbol:
+                continue
+            for filter_entry in symbol_info.get("filters", []):
+                if filter_entry.get("filterType") == "LOT_SIZE":
+                    step_size = Decimal(str(filter_entry.get("stepSize")))
+                    if step_size <= 0:
+                        raise ValueError(f"Invalid step size {step_size} for symbol {symbol}")
+                    self._step_size_cache[symbol] = step_size
+                    return step_size
+        raise ValueError(f"Unable to determine step size for symbol {symbol}")
+
+    def _determine_order_quantity(self, account_state: AccountState) -> Decimal:
+        if self.config.order_quantity is not None:
+            quantity = self.config.order_quantity
+            self._last_price = None
+        else:
+            if self.config.order_notional is None:  # pragma: no cover - guarded by config validation
+                raise ValueError("Bot configuration missing order size definition")
+            price = account_state.client.get_symbol_price(self.config.symbol)
+            if price <= 0:
+                raise ValueError(f"Received non-positive price {price} for {self.config.symbol}")
+            step_size = self._get_symbol_step_size(account_state.client, self.config.symbol)
+            quantity = (self.config.order_notional / price).quantize(step_size, rounding=ROUND_DOWN)
+            if quantity <= 0:
+                raise ValueError(
+                    "Derived order quantity is zero; increase order_notional or check symbol filters."
+                )
+            self._last_price = price
+        self._last_quantity = quantity
+        return quantity
+
+    def _order_parameters(self, account_state: AccountState) -> Dict[str, Decimal]:
+        quantity = self._determine_order_quantity(account_state)
+        return {"quantity": quantity}
 
     # ------------------------------------------------------------------
     # Public API
@@ -172,7 +212,7 @@ class DeltaNeutralVolumeBot:
             _paint("Starting", BOLD, FG_CYAN),
             _paint("delta-neutral volume bot", DIM),
             _paint(self.config.symbol, BOLD, FG_CYAN),
-            self._order_description(),
+            self._order_description(self._last_quantity),
         )
         self._prepare_accounts()
         effective_max_cycles = max_cycles if max_cycles is not None else self.config.max_cycles
@@ -260,7 +300,8 @@ class DeltaNeutralVolumeBot:
         if self.config.dry_run:
             return self._simulate_trade(account_state, side)
 
-        order_kwargs = self._order_parameters()
+        order_kwargs = self._order_parameters(account_state)
+        quantity = order_kwargs["quantity"]
         order_result = account_state.client.place_order(
             symbol=self.config.symbol,
             side=side,
@@ -275,7 +316,7 @@ class DeltaNeutralVolumeBot:
             self._account_label(account_state),
             _paint(str(order_result.order_id), FG_CYAN, BOLD),
             self._format_order_side(side),
-            self._order_description(),
+            self._order_description(quantity),
         )
         filled_order = self._wait_for_fill(account_state, order_result.order_id)
         trade_records = list(self._fetch_trade_records(account_state, filled_order))
@@ -335,13 +376,12 @@ class DeltaNeutralVolumeBot:
     # ------------------------------------------------------------------
     def _simulate_trade(self, account_state: AccountState, side: str) -> Sequence[TradeRecord]:
         now = int(time.time() * 1000)
-        price = Decimal("1")
+        qty = self._determine_order_quantity(account_state)
         if self.config.order_quantity is not None:
-            qty = self.config.order_quantity
-            quote_qty = qty * price
+            price = account_state.client.get_symbol_price(self.config.symbol)
         else:
-            quote_qty = self.config.order_notional if self.config.order_notional is not None else Decimal("0")
-            qty = quote_qty / price if price else quote_qty
+            price = self._last_price if self._last_price is not None else account_state.client.get_symbol_price(self.config.symbol)
+        quote_qty = qty * price
         commission = quote_qty * Decimal("0.0004") * Decimal("-1")
         record = TradeRecord(
             account=account_state.name,
@@ -358,7 +398,7 @@ class DeltaNeutralVolumeBot:
             "%s Simulated %s trade %s",
             self._account_label(account_state),
             self._format_order_side(side),
-            self._order_description(),
+            self._order_description(qty),
         )
         return [record]
 
@@ -389,7 +429,9 @@ class DeltaNeutralVolumeBot:
             "total_fees": str(self.total_fees),
             "target_volume": str(self.config.target_volume) if self.config.target_volume else None,
             "order_value": str(self.config.order_notional) if self.config.order_notional is not None else None,
-            "order_quantity": str(self.config.order_quantity) if self.config.order_quantity is not None else None,
+            "order_quantity": str(self._last_quantity)
+            if self._last_quantity is not None
+            else (str(self.config.order_quantity) if self.config.order_quantity is not None else None),
             "leverage": self.config.leverage,
             "margin_type": self.config.margin_type,
             "hedge_mode": self.config.hedge_mode,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_DOWN
+
+import pytest
+
+from aster_volume_bot.api import OrderResult
+from aster_volume_bot.bot import DeltaNeutralVolumeBot
+from aster_volume_bot.config import AccountConfig, BotConfig
+
+
+class FakeApiClient:
+    def __init__(self, api_key: str, api_secret: str) -> None:
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.place_order_calls = []
+        self.exchange_info_calls = 0
+        self._price = Decimal("16345")
+
+    def get_symbol_price(self, symbol: str) -> Decimal:
+        return self._price
+
+    def get_exchange_info(self, symbol: str | None = None) -> dict:
+        self.exchange_info_calls += 1
+        return {
+            "symbols": [
+                {
+                    "symbol": symbol,
+                    "filters": [
+                        {
+                            "filterType": "LOT_SIZE",
+                            "stepSize": "0.001",
+                        }
+                    ],
+                }
+            ]
+        }
+
+    # ------------------------------------------------------------------
+    # No-op stubs for methods exercised during tests
+    # ------------------------------------------------------------------
+    def change_position_mode(self, *_args, **_kwargs) -> None:  # pragma: no cover - unused in tests
+        pass
+
+    def change_leverage(self, *_args, **_kwargs) -> None:  # pragma: no cover - unused in tests
+        pass
+
+    def change_margin_type(self, *_args, **_kwargs) -> None:  # pragma: no cover - unused in tests
+        pass
+
+    def place_order(
+        self,
+        symbol: str,
+        side: str,
+        order_type: str,
+        quantity: Decimal | None = None,
+        position_side: str | None = None,
+        time_in_force: str | None = None,
+        reduce_only: bool | None = None,
+        price: Decimal | None = None,
+        new_client_order_id: str | None = None,
+        close_position: bool | None = None,
+        working_type: str | None = None,
+        stop_price: Decimal | None = None,
+        callback_rate: Decimal | None = None,
+        activation_price: Decimal | None = None,
+        new_order_resp_type: str | None = None,
+        recv_window: int | None = None,
+        quote_order_qty: Decimal | None = None,
+    ) -> OrderResult:
+        call = {
+            "symbol": symbol,
+            "side": side,
+            "order_type": order_type,
+            "quantity": quantity,
+            "quote_order_qty": quote_order_qty,
+            "position_side": position_side,
+        }
+        self.place_order_calls.append(call)
+        return OrderResult(
+            order_id=1,
+            status="FILLED",
+            executed_qty=Decimal("0"),
+            cum_quote=Decimal("0"),
+            avg_price=Decimal("0"),
+            update_time=0,
+        )
+
+    def query_order(self, *_args, **_kwargs) -> dict:  # pragma: no cover - unused thanks to patching
+        return {"status": "FILLED", "orderId": 1}
+
+    def get_account_trades(self, *_args, **_kwargs):  # pragma: no cover - unused thanks to patching
+        return []
+
+
+@pytest.fixture(autouse=True)
+def _patch_api_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("aster_volume_bot.bot.ApiClient", FakeApiClient)
+
+
+def make_bot(*, dry_run: bool = False) -> DeltaNeutralVolumeBot:
+    long_account = AccountConfig(name="long", api_key="k", api_secret="s")
+    short_account = AccountConfig(name="short", api_key="k", api_secret="s")
+    config = BotConfig(
+        symbol="BTCUSDT",
+        leverage=10,
+        order_notional=Decimal("25"),
+        order_quantity=None,
+        dry_run=dry_run,
+    )
+    return DeltaNeutralVolumeBot(long_account, short_account, config)
+
+
+def test_order_notional_converted_to_quantity(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = make_bot()
+    bot._wait_for_fill = lambda *args, **kwargs: {"orderId": 1}
+    bot._fetch_trade_records = lambda *args, **kwargs: []
+
+    trades = bot._place_and_wait(bot.long, side="BUY")
+    assert trades == []
+
+    call = bot.long.client.place_order_calls[0]
+    expected_qty = (Decimal("25") / Decimal("16345")).quantize(Decimal("0.001"), rounding=ROUND_DOWN)
+    assert call["quantity"] == expected_qty
+    assert call["quote_order_qty"] is None
+    assert bot.long.client.exchange_info_calls == 1
+
+    # Subsequent orders reuse the cached step size rather than re-fetching exchange info.
+    bot._place_and_wait(bot.long, side="SELL")
+    assert bot.long.client.exchange_info_calls == 1
+
+
+def test_dry_run_uses_computed_quantity() -> None:
+    bot = make_bot(dry_run=True)
+    trades = bot._simulate_trade(bot.long, side="BUY")
+    expected_qty = (Decimal("25") / Decimal("16345")).quantize(Decimal("0.001"), rounding=ROUND_DOWN)
+    assert trades[0].qty == expected_qty
+    assert trades[0].quote_qty == expected_qty * Decimal("16345")


### PR DESCRIPTION
## Summary
- add helpers on the API client to retrieve latest symbol prices and exchange metadata
- derive compliant base quantities for notional orders using cached step sizes and reuse them for logging/status bookkeeping
- add regression tests covering quantity submission and dry-run sizing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d59d21229483239066364a8b94339d